### PR TITLE
fix: changed Waste DAO to only return waste if it is marked as enabled

### DIFF
--- a/src/main/java/nl/groep14/ipsen2BE/DAO/WasteDAO.java
+++ b/src/main/java/nl/groep14/ipsen2BE/DAO/WasteDAO.java
@@ -31,7 +31,7 @@ public class WasteDAO {
      * @return arrayList of Waste
      */
     public ArrayList<Waste> getAll(){
-        return (ArrayList<Waste>) this.wasteRepository.findAll();
+        return this.wasteRepository.getAllByEnabled(true);
     }
     /**
      * Attempts to return a single Waste if one exists in the database with the given id.
@@ -48,7 +48,7 @@ public class WasteDAO {
      * @return A Waste if a Waste with the Article id exists.
      */
     public Optional<Waste> getWasteByCutWasteId(Long id){
-        return this.wasteRepository.getWasteByCutWasteId(id);
+        return this.wasteRepository.getWasteByCutwasteId(id);
     }
     /**
      * Attempts to return a List of Waste if at least one exists in the database with the given Category id.
@@ -56,7 +56,7 @@ public class WasteDAO {
      * @return An arraylist of Waste if at least one Waste with the cateory id exists.
      */
     public Optional<ArrayList<Waste>> getWasteByCategoryId(Long id){
-        return this.wasteRepository.getWasteByCategoryId(id);
+        return this.wasteRepository.getAllByCategoryIdAndEnabled(id, true);
     }
 
 }

--- a/src/main/java/nl/groep14/ipsen2BE/DAO/WasteRepository.java
+++ b/src/main/java/nl/groep14/ipsen2BE/DAO/WasteRepository.java
@@ -10,9 +10,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 public interface WasteRepository extends JpaRepository<Waste,Long> {
-    @Query(value = "SELECT w from Waste w where w.cutwasteId = :cutWasteId")
-    Optional<Waste> getWasteByCutWasteId(@Param("cutWasteId") long cutWasteId);
-
-    @Query(value = "SELECT w from Waste w where w.categoryId = :categoryId")
-    Optional<ArrayList<Waste>> getWasteByCategoryId(@Param("categoryId") long categoryId);
+    ArrayList<Waste> getAllByEnabled(boolean enabled);
+    Optional<Waste> getWasteByCutwasteId(long cutwasteId);
+    Optional<ArrayList<Waste>> getAllByCategoryIdAndEnabled(long categoryId, boolean enabled);
 }

--- a/src/main/java/nl/groep14/ipsen2BE/Services/WasteFilterService.java
+++ b/src/main/java/nl/groep14/ipsen2BE/Services/WasteFilterService.java
@@ -218,7 +218,7 @@ public class WasteFilterService {
 
         for (Waste waste : allWastePerCategory
         ) {
-            cutwastePerCategory.add(cutWasteDAO.getById(waste.getId()));
+            cutwastePerCategory.add(cutWasteDAO.getById(waste.getCutwasteId()));
         }
         return cutwastePerCategory;
     }


### PR DESCRIPTION
UC-14 dashboard info gecategoriseerd afval
 
## Omschrijving
 
kleine fix waarbij nu alleen details van afval worden getoond wanneer deze geprocessed zijn (ze staan dan in de database op 'enabled'

## How-to-demo
1. start de back-end in branch "fix-filterWaste".
2. import de volgende sql dump in mysql WorkBench: 
[feat-processWaste.zip](https://github.com/SRvanBeek/WasteProcessingBE/files/10208757/feat-processWaste.zip)
3. open PostMan.
4. ga naar de tab 'Authorization'.
5.  selecteer type = 'bearer' en voeg deze token toe: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsInJvbGVzIjpbIlJPTEVfQURNSU4iXSwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2FwaS9sb2dpbiJ9.WMPk8OAQ3KjaCMOkxWAuo8TsW_SxDS98JyrPY6d4uGc"
6. zet de request type op 'GET'
7. vul "http://localhost:8080/api/waste/composition/A1" in en klik op 'send'.
8. de volgende response wordt gegeven: 
![image](https://user-images.githubusercontent.com/98340521/207067159-49e6257a-0bd0-401c-8d33-cae20a78ebef.png)
9. vul "http://localhost:8080/api/waste/details" in en klik op 'send'.
10. de volgende response wordt gegeven: 
![image](https://user-images.githubusercontent.com/98340521/207067064-4596784c-8a36-4b5f-8d3d-e36bebe948a8.png)
11. vul "http://localhost:8080/api/waste/details/A1" in en klik op 'send
12. de volgende response wordt gegeven:
![image](https://user-images.githubusercontent.com/98340521/207066886-3e356b74-4dcd-40d2-927e-9e9208e5015d.png)


## Checklist
 
Loop alle onderstaande punten na en zet een `x` in alle vakjes die van toepassing zijn.
 
- [x] Mijn pull request is voor één story/feature.
- [x] Elke individuele commit in dit pull request is logisch.
- [x] Alle code, documentatie en commits zijn in het Engels.
- [x] Ik heb overbodige/ongebruikte code weggegooid.
- [x] Als mijn wijziging veranderingen in de documentatie vereist, dan heb ik dat bijgewerkt.

